### PR TITLE
Checking type not to be undefined

### DIFF
--- a/src/uncontrollable.js
+++ b/src/uncontrollable.js
@@ -40,7 +40,9 @@ module.exports = function(Component, controlledValues, taps) {
               , prop)
 
             obj[prop] = customPropType(handler, type)
-            obj[defaultKey(prop)] = type
+            if(type !== undefined ) {
+              obj[defaultKey(prop)] = type;
+            }
           }, {});
     }
 


### PR DESCRIPTION
This was causing Jest to fail when trying to mock DateTimePicker for react-widgets project.