### PR TITLE
Reset prop value if defaultValue changes

### DIFF
--- a/src/createUncontrollable.js
+++ b/src/createUncontrollable.js
@@ -46,6 +46,7 @@ export default function createUncontrollable(mixins, set){
 
       /**
        * If a prop switches from controlled to Uncontrolled
+       * or if the prop's default counterpart changes
        * reset its value to the defaultValue
        */
       componentWillReceiveProps(nextProps){
@@ -57,6 +58,11 @@ export default function createUncontrollable(mixins, set){
            && utils.getValue(props, key) !== undefined)
            {
              this._values[key] = nextProps[utils.defaultKey(key)]
+           }
+          else if (utils.getValue(nextProps, utils.defaultKey(key))
+           !== utils.getValue(props, utils.defaultKey(key)))
+           {
+             this._values[key] = nextProps[utils.defaultKey(key)];
            }
         })
       },


### PR DESCRIPTION
### Proposed Change

If the value being passed into the `default${propName}` prop changes, then the actual value should change to the newly passed in value.
### Why?

One example of a problem this solves comes up when trying to use the `defaultValue` prop of two comboboxes, and the selection in one affects the `data` prop in the other. I've provided a brief illustration to clarify.
##### Current Behavior

When I select a new option in the left Combobox, the right Combobox gets a new `data` prop, and its `defaultValue` prop is reset to `undefined`. This is done because the data populating the right Combobox's options is dependent on the selected item in the left Combobox.

Unfortunately, as the gif shows, Uncontrollable currently prevents this change from getting to the actual Combobox, so it doesn't render as we'd like it to.
![dependent-comboboxes-noreset](https://cloud.githubusercontent.com/assets/901035/15000829/7ae9e502-1147-11e6-8e33-f7377042b1e2.gif)
##### New Behavior

With this change applied, the Combobox re-renders as we expect when the value passed into its `defaultValue` is changed.
![dependent-comboboxes-reset](https://cloud.githubusercontent.com/assets/901035/15001045/2671a5c6-1149-11e6-9245-0c96ff7eca6f.gif)
### Concerns

We haven't seen anything break in our app since this change went live in our fork back in late January, but it's still probably worth considering whether this might have otherwise breaking changes for other use cases.
