### PR TITLE
Remove Typo and format some code

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ var SimpleDropdown = React.createClass({
 
 Notice how we don't track any state in our simple dropdown? This is great because a consumer of our module will have the all the flexibility to decide what the behavior of the dropdown should be. Also notice our public API (propTypes), it consists of common pattern: a property we want set (`value`, `open`), and a set of handlers that indicate _when_ we want them set (`onChange`, `onToggle`). It is up to the parent component to change the `value` and `open` props in response to the handlers.
 
-While this pattern offers a excellent amount of flexibility to consumers, it also requires them to write a bunch of boilerplate code that probably won't change much from use to use. In all likelihood they will always want to set `open` in response to `onToggle`, and only in rare cases will want to override that behavior. This is where the controlled/uncontrolled pattern comes in.
+While this pattern offers an excellent amount of flexibility to consumers, it also requires them to write a bunch of boilerplate code that probably won't change much from use to use. In all likelihood they will always want to set `open` in response to `onToggle`, and only in rare cases will want to override that behavior. This is where the controlled/uncontrolled pattern comes in.
 
 We want to just handle the open/onToggle case ourselves if the consumer doesn't provide a `open` prop (indicating that they want to control it). Rather than complicating our dropdown component with all that logic, obscuring the business logic of our dropdown, we can add it later, by taking our dropdown and wrapping it inside another component that handles that for us.
 

--- a/test/test.js
+++ b/test/test.js
@@ -10,10 +10,10 @@ var render = TestUtils.renderIntoDocument
   , findType = TestUtils.findRenderedComponentWithType
   , trigger = TestUtils.Simulate;
 
-describe('uncontrollable', () =>{
+describe('uncontrollable', () => {
   var Base;
 
-  beforeEach(()=> {
+  beforeEach(() => {
     Base = React.createClass({
 
       propTypes: {
@@ -67,7 +67,7 @@ describe('uncontrollable', () =>{
     })
   })
 
-  describe('common behavior', ()=>{
+  describe('common behavior', () => {
     var obj = {
       'classic': uncontrol,
       'batching': batching
@@ -76,7 +76,7 @@ describe('uncontrollable', () =>{
     Object.keys(obj).forEach(type => {
       var method = obj[type];
 
-      describe(type, ()=> {
+      describe(type, () => {
 
         it('should warn when handlers are missing', () => {
           var Control  = method(Base, { value: 'onChange' })
@@ -161,7 +161,7 @@ describe('uncontrollable', () =>{
           console.error.restore();
         })
 
-        it('should pass through methods.', () => {
+        it('should pass through methods', () => {
           var Control  = method(Base, { value: 'onChange' }, ['foo'])
             , instance = render(<Control defaultValue={10} defaultOpen />);
 
@@ -211,8 +211,7 @@ describe('uncontrollable', () =>{
 
           findClass(instance, 'open')
 
-          expect(()=>
-            base.nonBatchingChange(42)).not.to.throw()
+          expect(() => base.nonBatchingChange(42)).not.to.throw()
 
           spy.should.have.been.calledOnce
 
@@ -254,7 +253,6 @@ describe('uncontrollable', () =>{
           var Parent = React.createClass({
             getInitialState(){ return { value: 5 } },
             render(){
-
               return (
                 <Control
                   ref='ctrl'
@@ -285,7 +283,7 @@ describe('uncontrollable', () =>{
     })
   })
 
-  describe('batching specific behavior', ()=>{
+  describe('batching specific behavior', () => {
     class Layer {
 
       constructor(container, render){
@@ -338,7 +336,7 @@ describe('uncontrollable', () =>{
         componentDidMount() {this._renderOverlay()},
         _renderOverlay() {
           if (!this._layer)
-            this._layer = new Layer(document.body, ()=> this._child)
+            this._layer = new Layer(document.body, () => this._child)
 
           this.layerInstance = this._layer.render()
         },


### PR DESCRIPTION
**What?**
Fix a typo in the documentation. And as a drive by fix I formated the code a bit mostly spaces.
