### PR TITLE
Add support to react 15.4.0

### DIFF
--- a/lib/batching.js
+++ b/lib/batching.js
@@ -2,7 +2,7 @@
 
 exports.__esModule = true;
 
-var _ReactUpdates = require('react/lib/ReactUpdates');
+var _ReactUpdates = require('react-dom/lib/ReactUpdates');
 
 var _ReactUpdates2 = _interopRequireDefault(_ReactUpdates);
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "release": "release"
   },
   "peerDependencies": {
-    "react": ">=0.11.0"
+    "react": ">=0.11.0",
+    "react-dom": ">= 0.11.0"
   },
   "release-script": {
     "altPkgRootFolder": "lib"

--- a/src/batching.js
+++ b/src/batching.js
@@ -1,4 +1,4 @@
-import ReactUpdates from 'react/lib/ReactUpdates';
+import ReactUpdates from 'react-dom/lib/ReactUpdates';
 import createUncontrollable  from './createUncontrollable';
 
 let mixin = {


### PR DESCRIPTION
Hello! Since react 15.4.0 `ReactUpdates` was moved from `react` module to `react-dom`. Tests also fails because of some deps (`bill` and `teaspoon`) so they fails but the library is working for me in production.